### PR TITLE
Lobby page - Edit issue modal window

### DIFF
--- a/client/src/components/modals/connect-modal/connect-modal.tsx
+++ b/client/src/components/modals/connect-modal/connect-modal.tsx
@@ -2,11 +2,11 @@ import { ChangeEvent, useState, useEffect } from 'react';
 import { TextField, Button } from '@material-ui/core';
 import Switch from '@material-ui/core/Switch';
 import { CustomAvatar } from '@components/ui/customAvatar/customAvatar';
-import { IConnectModalErrors } from '@models/types';
+import { IConnectModalErrors, IModalWindow } from '@models/types';
 import { ModalWrapper } from '../modal-wrapper/modal-wrapper.tsx';
 import './connect-modal.sass';
 
-const ConnectModal = ({ isOpen, onClose }) => {
+const ConnectModal = ({ isOpen, onClose }: IModalWindow) => {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [jobPosition, setJobPosition] = useState('');

--- a/client/src/components/modals/edit-issue-modal/edit-issue-modal.sass
+++ b/client/src/components/modals/edit-issue-modal/edit-issue-modal.sass
@@ -1,0 +1,15 @@
+.issue-modal
+  display: flex
+  flex-direction: column
+  max-width: 60%
+  margin: 0 auto
+
+  .text-input-issue-modal
+    margin-bottom: 35px
+
+.select-modal
+  display: flex
+  flex-direction: column
+
+.select-label
+  margin-bottom: 10px

--- a/client/src/components/modals/edit-issue-modal/edit-issue-modal.tsx
+++ b/client/src/components/modals/edit-issue-modal/edit-issue-modal.tsx
@@ -1,0 +1,111 @@
+import { ChangeEvent, useState, useEffect } from 'react';
+import { InputLabel, MenuItem, Select, TextField } from '@material-ui/core';
+import { IEditIssueModalErrors, IssuePriority } from '@models/types';
+import { ModalWrapper } from '../modal-wrapper/modal-wrapper.tsx';
+import { issueData } from './edit-issueData';
+import './edit-issue-modal.sass';
+
+const EditIssueModal = ({ isOpen, onClose }: any) => {
+  const [inputSettings, setInputSettings] = useState({
+    titleIssue: '',
+    linkIssue: '',
+  });
+  const [priopityIssue, setPriopityIssue] = useState(IssuePriority.HIGH);
+  const [errors, setErrors] = useState({} as IEditIssueModalErrors);
+
+  const clearForm = () => {
+    setInputSettings({ titleIssue: '', linkIssue: '' });
+    setPriopityIssue(IssuePriority.HIGH);
+    setErrors({} as IEditIssueModalErrors);
+  };
+
+  const validate = () => {
+    if (!inputSettings.titleIssue) {
+      setErrors({ ...errors, titleIssueError: true });
+    } else if (!inputSettings.linkIssue) {
+      setErrors({ ...errors, linkIssueError: true });
+    } else {
+      const newErrors = { ...errors };
+      delete newErrors.titleIssueError;
+      delete newErrors.linkIssueError;
+      setErrors(newErrors);
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) clearForm();
+  }, [isOpen]);
+
+  useEffect(() => {
+    validate();
+  }, [inputSettings.titleIssue, inputSettings.linkIssue, isOpen]);
+
+  const handleInput = (event: ChangeEvent<HTMLInputElement>) => {
+    setInputSettings({ ...inputSettings, [event.target.name]: event.target.value });
+  };
+
+  const handleChange = (event: ChangeEvent<any>) => {
+    setPriopityIssue(event.target.value);
+  };
+
+  const handleConfirm = () => {};
+
+  const modalBody = (
+    <div className="issue-modal">
+      <div className="text-input-issue-modal">
+        <div className="input-modal">
+          <TextField
+            label="Title"
+            name="titleIssue"
+            autoComplete="off"
+            fullWidth
+            value={inputSettings.titleIssue}
+            onChange={handleInput}
+            error={errors.titleIssueError === true}
+            required
+          />
+        </div>
+        <div className="input-modal">
+          <TextField
+            label="Link"
+            name="linkIssue"
+            autoComplete="off"
+            fullWidth
+            value={inputSettings.linkIssue}
+            onChange={handleInput}
+            error={errors.linkIssueError === true}
+            required
+          />
+        </div>
+      </div>
+      <div className="select-issue-modal">
+        <div className="select-modal">
+          <InputLabel className="select-label" htmlFor="priority-issue">
+            Set priority
+          </InputLabel>
+          <Select id="priority-issue" value={priopityIssue} onChange={handleChange}>
+            {issueData.map(({ title, value }) => (
+              <MenuItem key={title} value={value}>
+                {title}
+              </MenuItem>
+            ))}
+          </Select>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <ModalWrapper
+      isOpen={isOpen}
+      onClose={onClose}
+      onConfirm={handleConfirm}
+      title="Edit Issue"
+      disableConfirm={!!Object.keys(errors).length}
+    >
+      {modalBody}
+    </ModalWrapper>
+  );
+};
+
+export default EditIssueModal;

--- a/client/src/components/modals/edit-issue-modal/edit-issue-modal.tsx
+++ b/client/src/components/modals/edit-issue-modal/edit-issue-modal.tsx
@@ -1,11 +1,11 @@
 import { ChangeEvent, useState, useEffect } from 'react';
 import { InputLabel, MenuItem, Select, TextField } from '@material-ui/core';
-import { IEditIssueModalErrors, IssuePriority } from '@models/types';
+import { IEditIssueModalErrors, IModalWindow, IssuePriority } from '@models/types';
 import { ModalWrapper } from '../modal-wrapper/modal-wrapper.tsx';
 import { issueData } from './edit-issueData';
 import './edit-issue-modal.sass';
 
-const EditIssueModal = ({ isOpen, onClose }: any) => {
+const EditIssueModal = ({ isOpen, onClose }: IModalWindow) => {
   const [inputSettings, setInputSettings] = useState({
     titleIssue: '',
     linkIssue: '',
@@ -61,7 +61,7 @@ const EditIssueModal = ({ isOpen, onClose }: any) => {
             fullWidth
             value={inputSettings.titleIssue}
             onChange={handleInput}
-            error={errors.titleIssueError === true}
+            error={errors.titleIssueError}
             required
           />
         </div>
@@ -73,7 +73,7 @@ const EditIssueModal = ({ isOpen, onClose }: any) => {
             fullWidth
             value={inputSettings.linkIssue}
             onChange={handleInput}
-            error={errors.linkIssueError === true}
+            error={errors.linkIssueError}
             required
           />
         </div>

--- a/client/src/components/modals/edit-issue-modal/edit-issueData.ts
+++ b/client/src/components/modals/edit-issue-modal/edit-issueData.ts
@@ -1,0 +1,16 @@
+import { IssuePriority } from '@models/types';
+
+export const issueData = [
+  {
+    title: 'High Priority',
+    value: IssuePriority.HIGH,
+  },
+  {
+    title: 'Normal Priority',
+    value: IssuePriority.NORMAL,
+  },
+  {
+    title: 'Low Priority',
+    value: IssuePriority.LOW,
+  },
+];

--- a/client/src/components/modals/start-modal/start-modal.tsx
+++ b/client/src/components/modals/start-modal/start-modal.tsx
@@ -1,11 +1,11 @@
 import { ChangeEvent, useState, useEffect } from 'react';
 import { TextField, Button } from '@material-ui/core';
 import { CustomAvatar } from '@components/ui/customAvatar/customAvatar';
-import { IConnectModalErrors } from '@models/types';
+import { IConnectModalErrors, IModalWindow } from '@models/types';
 import { ModalWrapper } from '../modal-wrapper/modal-wrapper.tsx';
 import '../connect-modal/connect-modal.sass';
 
-const StartModal = ({ isOpen, onClose }) => {
+const StartModal = ({ isOpen, onClose }: IModalWindow) => {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [jobPosition, setJobPosition] = useState('');

--- a/client/src/components/ui/issueCard/issueCard.tsx
+++ b/client/src/components/ui/issueCard/issueCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import { useState } from 'react';
 import { Card, CardHeader, IconButton, makeStyles } from '@material-ui/core';
 import { IIssueCard } from '@models/types';
-import './issueCard.sass';
 import { truncateString } from '@utils/stringUtils';
+import EditIssueModal from '@components/modals/edit-issue-modal/edit-issue-modal';
+import './issueCard.sass';
 
 interface StyleProps {
   isSelected: boolean;
@@ -15,11 +16,17 @@ const useStyles = makeStyles({
 });
 
 export const IssueCard = ({ name, priority, isSelected, isGame }: IIssueCard) => {
-  const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
-    console.log(event.target);
+  const [editIssueModalOpen, setEditIssueModalOpen] = useState(false);
+
+  const handleEditIssueModalOpen = () => {
+    setEditIssueModalOpen(true);
   };
 
-  const handleEdit = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleEditIssueModalClose = () => {
+    setEditIssueModalOpen(false);
+  };
+
+  const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
     console.log(event.target);
   };
 
@@ -31,21 +38,24 @@ export const IssueCard = ({ name, priority, isSelected, isGame }: IIssueCard) =>
   const isueCardStyles = `issue-card ${classes.card}`;
 
   return (
-    <Card className={isueCardStyles}>
-      <CardHeader
-        className="issue-card-header"
-        title={truncateString(name)}
-        subheader={truncateString(priority)}
-        subheaderTypographyProps={{ variant: 'subtitle1' }}
-      />
-      {isGame ? (
-        <IconButton className="issue-card-close-btn" onClick={handleClose} />
-      ) : (
-        [
-          <IconButton className="issue-card-edit-btn" onClick={handleEdit} />,
-          <IconButton className="issue-card-delete-btn" onClick={handleDelete} />,
-        ]
-      )}
-    </Card>
+    <>
+      <Card className={isueCardStyles}>
+        <CardHeader
+          className="issue-card-header"
+          title={truncateString(name)}
+          subheader={truncateString(priority)}
+          subheaderTypographyProps={{ variant: 'subtitle1' }}
+        />
+        {isGame ? (
+          <IconButton className="issue-card-close-btn" onClick={handleClose} />
+        ) : (
+          [
+            <IconButton className="issue-card-edit-btn" onClick={handleEditIssueModalOpen} />,
+            <IconButton className="issue-card-delete-btn" onClick={handleDelete} />,
+          ]
+        )}
+      </Card>
+      <EditIssueModal isOpen={editIssueModalOpen} onClose={handleEditIssueModalClose} />
+    </>
   );
 };

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -97,7 +97,18 @@ export interface IConnectModalErrors {
   firstNameError?: boolean;
 }
 
-enum IssuePriority {
+export interface IEditIssueModalErrors {
+  /*
+   * title of Issue error
+   */
+  titleIssueError?: boolean;
+  /*
+   * link of Issue error
+   */
+  linkIssueError?: boolean;
+}
+
+export enum IssuePriority {
   HIGH = 'high',
   NORMAL = 'normal',
   LOW = 'low',

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -52,6 +52,8 @@ export interface IModalWrapper {
   disableConfirm: boolean;
 }
 
+export type IModalWindow = Pick<IModalWrapper, 'isOpen' | 'onClose'>;
+
 export interface IModalButtons {
   /*
    * confirmation button text

--- a/client/src/styles/main.sass
+++ b/client/src/styles/main.sass
@@ -6,7 +6,7 @@
   flex-direction: column
   height: 100%
   justify-content: space-between
-  
+
 .container
   max-width: 1440px
   margin: 0 auto
@@ -23,10 +23,10 @@
   &-active
     opacity: 1
     transition: opacity 0.3s ease-in
-    
+
 .error-down
   position: relative
-  
+
 .error-container
   position: absolute
   left: 0
@@ -56,6 +56,7 @@
   font-weight: 700
   margin-bottom: 20px
   color: $text-color
+  text-align: center
   @media (max-width: 700px)
     font-size: 30px
 


### PR DESCRIPTION
***Lobby page Edit Issue modal window***
![edit-issue-modal](https://user-images.githubusercontent.com/31656183/133937190-41cc99fd-da8c-4b7e-bf74-7466a07f7529.png)
In scope:
- [x] issue card: 
on edit issue icon button click should appear a "Edit issue" modal window like "Create Issue" modal, with the same React controlled fields (Title, Link, Priority) and cancel / save buttons